### PR TITLE
Serve and build fonts

### DIFF
--- a/config/webpack.base.conf.js
+++ b/config/webpack.base.conf.js
@@ -45,6 +45,11 @@ module.exports = {
         },
       },
       {
+        test: /fonts\/.*\.(eot|svg|ttf|woff|woff2)$/,
+        exclude: /node_modules/,
+        loader: 'file-loader',
+      },
+      {
         test: config.regex.images,
         exclude: /node_modules/,
         loader: ['file-loader', 'img-loader'],


### PR DESCRIPTION
Fonts found in `/src/assets/fonts` will be uploaded to Shopify (only if they are referenced from CSS). That's it.