### PR TITLE
Remove CSS source map - fixes #61

### DIFF
--- a/config/webpack.dev.conf.js
+++ b/config/webpack.dev.conf.js
@@ -26,8 +26,8 @@ module.exports = merge(webpackConfig, {
         test: /\.s[ac]ss$/,
         use: [
           { loader: 'style-loader' },
-          { loader: 'css-loader', options: { sourceMap: true } },
-          { loader: 'sass-loader', options: { sourceMap: true } }
+          { loader: 'css-loader' },
+          { loader: 'sass-loader' }
         ]
       }
     ]


### PR DESCRIPTION
Fixes #61 - see https://github.com/webpack-contrib/style-loader/issues/55 for details.

Basically, having the source maps enabled for CSS made CSS to load over the `blob:` protocol, which isn't supported in Shopify admin (it loads things in an iframe from the cdn and ... and it's the cdn (I think) that doesn't like `blob`). `publicPath` is correctly set but it's not doing what it should (at least I think) be doing for CSS...

Will look into this further but I think having #61 fixed is more important than CSS source maps.

@bourroush once this is merged in, you'll want to delete `yarn.lock` and run `yarn` again to download the newer version of this package.