### PR TITLE
Pass theme.liquid through the raw loader so it works with HTML webpack plugin

### DIFF
--- a/config/webpack.base.conf.js
+++ b/config/webpack.base.conf.js
@@ -74,9 +74,13 @@ module.exports = {
         }
       },
       {
+        test: /layout\/theme\.liquid$/,
+        exclude: /node_modules/,
+        loader: 'raw-loader'
+      },
+      {
         test: /\.liquid$/,
         exclude: /node_modules/,
-        include: /templates/,
         loader: `extract-loader!liquid-loader?dev-server=${isDevServer ? 'true' : 'false'}`
       }
     ]
@@ -97,7 +101,6 @@ module.exports = {
     }),
 
     new WriteFileWebpackPlugin({
-      // test: config.regex.static,
       test: /^(?:(?!hot-update.json$).)*\.(liquid|json)$/,
       useHashIndex: true,
       log: false

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "minimist": "1.2.0",
     "node-sass": "4.5.3",
     "postcss-loader": "2.0.5",
+    "raw-loader": "^0.5.1",
     "react-dev-utils": "0.5.2",
     "sass-loader": "6.0.5",
     "style-loader": "0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5249,6 +5249,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raw-loader@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
+
 rc@^1.1.2, rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"


### PR DESCRIPTION
Pass all liquid files to the `liquid-loader`, and then pass `theme.liquid` through the `raw-loader` so that `HTMLWebpackPlugin` can handle it.

Closes #76 