### PR TITLE
Ensure logos.svg is not parsed by the liquid loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,15 @@ Here are the steps necessary to use it:
 2. Somewhere in your JS application, you need to create this variable and assignment:
     ```
     var __svg__ = { path: '../svg/**/*.svg', name: 'logos.svg' };
-    ```
-    
+    ```    
     This will tell the SVG Store plugin [that it needs to generate the sprite file](https://github.com/mrsum/webpack-svgstore-plugin#2-put-function-mark-at-your-chunk).
     
-Note that the plugin will add a `icon-` prefix to your file name as the `id` of the symbol in the sprite. There is no way to change this at the moment. Given that this is less than an ideal integration, we will look for better ways to generate the store [in the future](#roadmap).
+**Note** that the plugin will add a `icon-` prefix to your file name as the `id` of the symbol in the sprite. There is no way to change this at the moment. Given that this is less than an ideal integration, we will look for better ways to generate the store [in the future](#roadmap).
+
+Also **note** that, if you want to reference the sprite file in your liquid templates, [you will need to make sure that the url is not parsed by Webpack](#how-to-prevent-webpack-from-parsing-some-liquid-methods-and-filters). You can do so by wrapping the liquid curly brackets in a single quote and the name of the sprite in double quotes, like so:
+```
+<div data-some-attribute='{{ "logos.svg" | asset_url }}'></div>
+```
 
 #### [7] Shopify Required
 
@@ -254,6 +258,11 @@ To do so, you must:
 
 ### You should not rely on liquid helpers in your JS and CSS files
 (More to come)
+
+### How to prevent Webpack from parsing some liquid methods and filters
+Webpack will loop through your liquid files and parse the liquid helpers to compile the relevant assets. For example, if it detects a `<img src="{{ 'lamp.png' | assert_url }}>"` in a file, it will grab that `lamp.png` image and pass it through the build process.
+
+If, for some reason, one file should not be picked up by Webpack, you can escape this process by wrapping the liquid curly brackets in single quotes, like so `<img src='{{ "lamp.png" | assert_url }}>'`. 
 
 ### How to make HMR-compliant code
 To be able to use some sweet sweet HMR in your flow, you either need to use a framework that supports it (e.g. React, Vue, etc.) or modify your JS modules to be HMR-compatible. More info on how to do that [here](http://andrewhfarmer.com/webpack-hmr-tutorial/#part-2-code-changes).

--- a/template/.eslintrc
+++ b/template/.eslintrc
@@ -4,5 +4,9 @@
     "semi": ["error", "never"],
     "no-console": ["error", { "allow": ["log", "warn"] }],
     "comma-dangle": ["error", "never"]
+  },
+  "env": {
+    "browser": true,
+    "jest": true
   }
 }

--- a/template/src/assets/js/index.js
+++ b/template/src/assets/js/index.js
@@ -8,4 +8,4 @@ import Foo from './utilities/foo'
 console.log(Foo.bar('Boom!'))
 
 // eslint-disable-next-line
-const __svg__ = { path: '../svg/**/*.svg', name: 'svgstore.[hash].svg' }
+const __svg__ = { path: '../svg/**/*.svg', name: 'logos.svg' }

--- a/template/src/layout/theme.liquid
+++ b/template/src/layout/theme.liquid
@@ -1,4 +1,5 @@
 {{ content_for_header }}
 {{ content_for_layout }}
 
-<div data-src="{{ 'logos.svg' | asset_url }}"></div>
+<!-- data-src will be the URL to the generated svg sprite -->
+<div data-src='{{ "logos.svg" | asset_url }}'></div>


### PR DESCRIPTION
The liquid-loader looks for single quotes inside curly braces, so to ensure that the logos.svg liquid expression isn't parsed by the liquid-loader, this reverse the quotes to double quotes inside the curly braces.