### PR TITLE
By Default, Exclude Sensitive Credentials from SCM

### DIFF
--- a/template/config/.gitignore
+++ b/template/config/.gitignore
@@ -1,0 +1,1 @@
+shopify.yml

--- a/template/config/.gitignore
+++ b/template/config/.gitignore
@@ -1,1 +1,0 @@
-shopify.yml

--- a/template/gitignore
+++ b/template/gitignore
@@ -15,3 +15,5 @@ yarn-error.log*
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+config/shopify.yml


### PR DESCRIPTION
Given the sensitive nature of credentials stored in `config/shopify.yml`, this PR proposes to include a `config/.gitignore`, which excludes the credentials file from source-control. This can overridden, of course, but this is a smart sensible default.