### PR TITLE
Add vendors directory that get's fully uploaded to Shopify

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Once Shopify Pipeline has created the scaffolding of your project, it will have 
     │   ├── js [4]
     │   └── sass [5]
     │   └── svg [6]
+    │   └── vendors [9]
     ├── config [7]
     │   ├── settings_data.json
     │   └── settings_schema.json
@@ -204,6 +205,14 @@ You can nest and organize your specs in subfolders as long as the filenames foll
 
 The `test` command is just a proxy for launching `jest` and as such we recommend you read [their documentation](https://facebook.github.io/jest/docs/getting-started.html) to learn more about the framework and how to use it.
 
+#### [9] Vendors
+
+`src/assets/vendors`
+
+Sometimes you need the ability to upload un-modified files to the Shopify server. This is where the `vendors` directory comes in. Any files placed inside this directory will be uploaded, as-is, to Shopify. To reference them in your `.liquid` files, you'll want to [ensure Webpack doesn't parse your liquid filters](how-to-prevent-webpack-from-parsing-some-liquid-methods-and-filters) when referencing those files.
+
+This special directory can be usefull for files added by plugins you've installed, or for when you need to construct an image URL in Liquid.
+
 ## Using the Tool
 
 ### Not Global
@@ -262,7 +271,7 @@ To do so, you must:
 ### How to prevent Webpack from parsing some liquid methods and filters
 Webpack will loop through your liquid files and parse the liquid helpers to compile the relevant assets. For example, if it detects a `<img src="{{ 'lamp.png' | assert_url }}>"` in a file, it will grab that `lamp.png` image and pass it through the build process.
 
-If, for some reason, one file should not be picked up by Webpack, you can escape this process by wrapping the liquid curly brackets in single quotes, like so `<img src='{{ "lamp.png" | assert_url }}>'`. 
+If, for some reason, one file should not be picked up by Webpack, you can escape this process by wrapping the liquid curly brackets in single quotes, like so `<img src='{{ "lamp.png" | assert_url }}>'`. When using this escape hatch, you should not include a relative link to your asset but instead simply write it's name.
 
 ### How to make HMR-compliant code
 To be able to use some sweet sweet HMR in your flow, you either need to use a framework that supports it (e.g. React, Vue, etc.) or modify your JS modules to be HMR-compatible. More info on how to do that [here](http://andrewhfarmer.com/webpack-hmr-tutorial/#part-2-code-changes).

--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ The `test` command is just a proxy for launching `jest` and as such we recommend
 
 `src/assets/vendors`
 
-Sometimes you need the ability to upload un-modified files to the Shopify server. This is where the `vendors` directory comes in. Any files placed inside this directory will be uploaded, as-is, to Shopify. To reference them in your `.liquid` files, you'll want to [ensure Webpack doesn't parse your liquid filters](how-to-prevent-webpack-from-parsing-some-liquid-methods-and-filters) when referencing those files.
+Sometimes you need the ability to upload unmodified files to the Shopify server. This is where the `vendors` directory comes in. Any files placed inside this directory will be uploaded, as-is, to Shopify. To reference them in your `.liquid` files, you'll want to [ensure Webpack doesn't parse your liquid filters](how-to-prevent-webpack-from-parsing-some-liquid-methods-and-filters) when referencing those files.
 
-This special directory can be usefull for files added by plugins you've installed, or for when you need to construct an image URL in Liquid.
+This special directory can be useful for files added by plugins you've installed, or for when you need to construct an image URL in Liquid.
 
 ## Using the Tool
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -41,6 +41,7 @@ module.exports = {
   root: appDirectory,
   dist: resolveApp('dist'),
   src: resolveApp('src'),
+  vendors: resolveApp('src/assets/vendors'),
   lib: resolveSelf('lib'),
   entrypoints: {
     scripts: resolveApp('src/assets/js/index.js'),

--- a/config/webpack.base.conf.js
+++ b/config/webpack.base.conf.js
@@ -6,6 +6,9 @@ const paths = require('../config/paths')
 
 const isDevServer = process.argv.find(v => v.includes('serve'))
 
+// Given a request path, return a function that accepts a context and modify it's request.
+const replaceCtxRequest = request => context => Object.assign(context, { request })
+
 module.exports = {
   context: paths.src,
 
@@ -87,12 +90,9 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.ContextReplacementPlugin(
-      /allstaticfiles/,
-      config.paths.src,
-      true,
-      /^(?:(?!theme\.liquid$).)*\.(liquid|json)$/
-    ),
+    // https://webpack.js.org/plugins/context-replacement-plugin/#newcontentcallback
+    new webpack.ContextReplacementPlugin(/__appsrc__/, replaceCtxRequest(paths.src)),
+    new webpack.ContextReplacementPlugin(/__appvendors__/, replaceCtxRequest(paths.vendors)),
 
     new WriteFileWebpackPlugin({
       test: config.regex.images,

--- a/config/webpack.base.conf.js
+++ b/config/webpack.base.conf.js
@@ -3,6 +3,7 @@ const config = require('../config')
 const WriteFileWebpackPlugin = require('write-file-webpack-plugin')
 const SvgStore = require('webpack-svgstore-plugin')
 const paths = require('../config/paths')
+const commonExcludes = require('../lib/common-excludes')
 
 const isDevServer = process.argv.find(v => v.includes('serve'))
 
@@ -20,7 +21,7 @@ module.exports = {
   },
 
   resolveLoader: {
-    modules: ['node_modules', config.paths.lib]
+    modules: [config.paths.lib, 'node_modules']
   },
 
   module: {
@@ -28,7 +29,7 @@ module.exports = {
       {
         enforce: 'pre',
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: commonExcludes(),
         loader: 'eslint-loader',
         options: {
           configFile: config.paths.eslintrc
@@ -36,7 +37,7 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: commonExcludes(),
         loader: 'babel-loader',
         options: {
           presets: [
@@ -51,7 +52,7 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: commonExcludes(),
         loader: 'hmr-alamo-loader'
       },
       {
@@ -61,7 +62,7 @@ module.exports = {
       },
       {
         test: config.regex.images,
-        exclude: /node_modules/,
+        exclude: commonExcludes(),
         use: [
           { loader: 'file-loader', options: { name: '[name].[hash].[ext]' } },
           { loader: 'img-loader' }
@@ -70,20 +71,28 @@ module.exports = {
       {
         test: config.regex.static,
         // excluding layout/theme.liquid as it's also being emitted by the HtmlWebpackPlugin
-        exclude: /(node_modules|layout\/theme\.liquid)/,
+        exclude: commonExcludes('layout/theme.liquid'),
         loader: 'file-loader',
         options: {
           name: '../[path][name].[ext]'
         }
       },
       {
-        test: /layout\/theme\.liquid$/,
+        test: /assets\/vendors\//,
         exclude: /node_modules/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]'
+        }
+      },
+      {
+        test: /layout\/theme\.liquid$/,
+        exclude: commonExcludes(),
         loader: 'raw-loader'
       },
       {
         test: /\.liquid$/,
-        exclude: /node_modules/,
+        exclude: commonExcludes(),
         loader: `extract-loader!liquid-loader?dev-server=${isDevServer ? 'true' : 'false'}`
       }
     ]
@@ -95,7 +104,7 @@ module.exports = {
     new webpack.ContextReplacementPlugin(/__appvendors__/, replaceCtxRequest(paths.vendors)),
 
     new WriteFileWebpackPlugin({
-      test: config.regex.images,
+      test: /\.(png|svg|jpf|gif|scss)/,
       useHashIndex: true,
       log: false
     }),

--- a/config/webpack.dev.conf.js
+++ b/config/webpack.dev.conf.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 const config = require('./index')
 const webpackConfig = require('./webpack.base.conf')
+const commonExcludes = require('../lib/common-excludes')
 const userWebpackConfig = require('../lib/get-user-webpack-config')('dev')
 
 // so that everything is absolute
@@ -24,6 +25,7 @@ module.exports = merge(webpackConfig, {
     rules: [
       {
         test: /\.s[ac]ss$/,
+        exclude: commonExcludes(),
         use: [
           { loader: 'style-loader' },
           { loader: 'css-loader' },

--- a/config/webpack.prod.conf.js
+++ b/config/webpack.prod.conf.js
@@ -2,6 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const merge = require('webpack-merge')
 const webpackConfig = require('./webpack.base.conf')
+const commonExcludes = require('../lib/common-excludes')
 const userWebpackConfig = require('../lib/get-user-webpack-config')('prod')
 
 const config = require('../config')
@@ -20,6 +21,7 @@ module.exports = merge(webpackConfig, {
     rules: [
       {
         test: /\.s[ac]ss$/,
+        exclude: commonExcludes(),
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
           use: [

--- a/lib/common-excludes.js
+++ b/lib/common-excludes.js
@@ -1,0 +1,5 @@
+module.exports = (...params) => new RegExp([
+  'node_modules',
+  'assets/vendors/',
+  ...params
+].join('|'))

--- a/lib/static-files-glob.js
+++ b/lib/static-files-glob.js
@@ -3,8 +3,9 @@
 //
 // What is this ? Why is this here ? Read on.
 //
-// This is used as an entry point in webpack.base.conf.js. It will dynamically
-// require all liquid and json files from the user's directory (except theme.liquid).
+// This is used as an entry point in webpack.base.conf.js. It dynamically
+// require all liquid and json files from the user's directory (except theme.liquid)
+// as well as everything inside the src/assets/vendors directory.
 //
 // Why not use require.context() you ask ? This would work if we'd want to require
 // files from this tool's directory, but not from the user's directory, as you can't
@@ -19,8 +20,10 @@
 // > You need to use the ContextReplacementPlugin in most cases.
 //
 // For the `ContextReplacementPlugin` to kick in, we need to make our require
-// dynamic, hence the use of a variable (`theDynamicPart`).
-// The context we look for, and replace, is the `allstaticfiles` part.
+// dynamic, hence the use of a variable (`dynamicCtx`).
+// The context we look for, and replace, is the `__app[src|vendors]__` part.
 //
-var theDynamicPart = 'salut';
-require('./allstaticfiles/' + theDynamicPart);
+var dynamicCtx = 'salut';
+require('__appsrc__/' + dynamicCtx + '.liquid');
+require('__appsrc__/' + dynamicCtx + '.json');
+require('__appvendors__/' + dynamicCtx);


### PR DESCRIPTION
Upload all files found inside the `src/assets/vendors` directory directly to Shopify's server, without passing them through any loader but the file-loader.

Closes #89 